### PR TITLE
Update version specified in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Available on [crates.io](https://crates.io/crates/shadow-drive-rust).
 Add the crate to your `Cargo.toml`.
 
 ```toml
-shadow-drive-rust = "0.1.0"
+shadow-drive-rust = "0.3.0"
 ```
 
 ### Examples


### PR DESCRIPTION
This proposed change updates the version specified in the readme to match the latest version published on crates.io which is 0.3.0.